### PR TITLE
Remove fake IP filter for heiyu.space in DNS settings

### DIFF
--- a/docs/03-客户端共存/iOS/iOSstash配置/lzc.stash
+++ b/docs/03-客户端共存/iOS/iOSstash配置/lzc.stash
@@ -47,7 +47,6 @@ rules:
 # 4. DNS 设置
 dns:
   fake-ip-filter:
-    - '+.heiyu.space'
     - '+.lazycat.cloud'
 
 # 5. TUN 设置


### PR DESCRIPTION
Remove the fake IP filter rule for heiyu.space to ensure compatibility with pure IPv4 environments.